### PR TITLE
Allow specifying mime type on upload

### DIFF
--- a/lib/actions/file.js
+++ b/lib/actions/file.js
@@ -12,13 +12,14 @@ exports.uploadFile = function(b2, args) {
     var filename = utils.getUrlEncodedFileName(args.filename);
     var data = args.data;
     var info = args.info;
+    var mime = args.mime;
 
     var options = {
         url: uploadUrl,
         method: 'POST',
         headers: {
             Authorization: uploadAuthToken,
-            'Content-Type': 'b2/x-auto',
+            'Content-Type': mime || 'b2/x-auto',
             'X-Bz-File-Name': filename,
             'X-Bz-Content-Sha1': data ? sha1(data) : null
         },


### PR DESCRIPTION
Useful for files without extension, as auto-detection doesn't work in that case.