### PR TITLE
Fix setting encoding for request options in downloadFileById.

### DIFF
--- a/lib/actions/file.js
+++ b/lib/actions/file.js
@@ -117,7 +117,8 @@ exports.downloadFileById = function(b2, fileId) {
         qs: {
             fileId: fileId
         },
-        headers: utils.getAuthHeaderObjectWithToken(b2)
+        headers: utils.getAuthHeaderObjectWithToken(b2),
+        encoding: null
     };
 
     var deferred = q.defer();

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "eslint": "^1.10.1",
+    "eslint": "^2.4.0",
     "expect.js": "^0.3.1",
     "mocha": "^2.3.4"
   },

--- a/test/unit/lib/actions/fileTest.js
+++ b/test/unit/lib/actions/fileTest.js
@@ -483,7 +483,8 @@ describe('actions/file', function() {
                     },
                     headers: {
                         Authorization: 'unicorns and rainbows'
-                    }
+                    },
+                    encoding: null
                 });
                 expect(actualResponse).to.eql({
                     data: 'file contents',


### PR DESCRIPTION
Updated unit test.
Updated eslint version.

This fixes issue #15 