### PR TITLE
Feature: Promise Progress Notifications

### DIFF
--- a/lib/actions/file.js
+++ b/lib/actions/file.js
@@ -5,6 +5,7 @@ var utils = require('./../utils');
 var headersUtil = require('../headers');
 var request = require('../request');
 var conf = require('../../conf');
+var progress = require('request-progress');
 
 exports.uploadFile = function(b2, args) {
     var uploadUrl = args.uploadUrl;
@@ -112,7 +113,10 @@ exports.downloadFileByName = function(b2, args) {
     var deferred = q.defer();
 
     var requestInstance = request.getInstance();
-    requestInstance(options, utils.getProcessFileSuccess(deferred, processDownloadResponse));
+    progress(requestInstance(options, utils.getProcessFileSuccess(deferred, processDownloadResponse)))
+        .on('progress', function (state) {
+            deferred.notify(state);
+        });
 
     return deferred.promise;
 };
@@ -130,7 +134,10 @@ exports.downloadFileById = function(b2, fileId) {
     var deferred = q.defer();
 
     var requestInstance = request.getInstance();
-    requestInstance(options, utils.getProcessFileSuccess(deferred, processDownloadResponse));
+    progress(requestInstance(options, utils.getProcessFileSuccess(deferred, processDownloadResponse)))
+        .on('progress', function (state) {
+            deferred.notify(state);
+        });
 
     return deferred.promise;
 };

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,6 +1,8 @@
 var q = require('q');
+var progress = require('request-progress');
 
 var utils = require('./utils');
+
 
 var REQUEST;
 
@@ -12,7 +14,10 @@ exports.sendRequest = function(options) {
     var deferred = q.defer();
 
     var requestInstance = exports.getInstance();
-    requestInstance(options, utils.processResponseGeneric(deferred));
+    progress(requestInstance(options, utils.processResponseGeneric(deferred)))
+        .on('progress', function (state) {
+            deferred.notify(state);
+        });
 
     return deferred.promise;
 };

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "node-sha1": "^1.0.1",
     "q": "^1.4.1",
-    "request": "^2.67.0"
+    "request": "^2.67.0",
+    "request-progress": "^3.0.0"
   }
 }

--- a/test/unit/lib/actions/bucketTest.js
+++ b/test/unit/lib/actions/bucketTest.js
@@ -24,6 +24,11 @@ describe('actions/bucket', function() {
         bogusRequestModule = function(options, cb) {
             requestOptions = options;
             cb(errorMessage, false, JSON.stringify(response));
+            var  bogusRequestObject = function() {
+                // Fake event subscribe that supports method chaining
+                this.on = function() {return this;};
+            };
+            return new bogusRequestObject();
         };
 
         request.setup(bogusRequestModule);

--- a/test/unit/lib/actions/fileTest.js
+++ b/test/unit/lib/actions/fileTest.js
@@ -26,6 +26,12 @@ describe('actions/file', function() {
         bogusRequestModule = function(options, cb) {
             requestOptions = options;
             cb(errorMessage, false, JSON.stringify(response));
+            // Well, we can't return undefined, now can we?
+            var  bogusRequestObject = function() {
+                // Fake event subscribe that supports method chaining
+                this.on = function() {return this;};
+            };
+            return new bogusRequestObject();
         };
 
         request.setup(bogusRequestModule);
@@ -403,6 +409,12 @@ describe('actions/file', function() {
                 bogusRequestModule = function(options, cb) {
                     requestOptions = options;
                     cb(errorMessage, response, 'file contents');
+                    // Well, we can't return undefined, now can we?
+                    var  bogusRequestObject = function() {
+                        // Fake event subscribe that supports method chaining
+                        this.on = function() {return this;};
+                    };
+                    return new bogusRequestObject();
                 };
 
                 request.setup(bogusRequestModule);
@@ -465,6 +477,12 @@ describe('actions/file', function() {
                 bogusRequestModule = function(options, cb) {
                     requestOptions = options;
                     cb(errorMessage, response, 'file contents');
+                    // Well, we can't return undefined, now can we?
+                    var  bogusRequestObject = function() {
+                        // Fake event subscribe that supports method chaining
+                        this.on = function() {return this;};
+                    };
+                    return new bogusRequestObject();
                 };
 
                 request.setup(bogusRequestModule);

--- a/test/unit/lib/requestTest.js
+++ b/test/unit/lib/requestTest.js
@@ -11,6 +11,12 @@ describe('request', function() {
         beforeEach(function() {
             bogusRequestModule = function(options, cb) {
                 cb(false, false, JSON.stringify(options));
+                // Well, we can't return undefined, now can we?
+                var  bogusRequestObject = function() {
+                    // Fake event subscribe that supports method chaining
+                    this.on = function() {return this;};
+                };
+                return new bogusRequestObject();
             };
             options = { unicorn: 'rainbows' };
             request.setup(bogusRequestModule);


### PR DESCRIPTION
It uses `deferred.notify()` to report upload/download progress on the `request` module. Spent the bigger part of 3 hours trying to get tests to pass, but I couldn't for the life of me get it to work. Need to add this code into the request module mock:
```
var  bogusRequestModuleObject = function() {};
bogusRequestModuleObject.prototype.on = function(e, cb) {/* Fake listener registration */}; // eslint-disable-line
return new bogusRequestModuleObject();
```