### PR TITLE
Hash argument for uploadFile()

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,9 @@ var response = await this.b2.finishLargeFile({
         uploadUrl: 'uploadUrl',
         uploadAuthToken: 'uploadAuthToken',
         filename: 'filename',
-        mime: '', // optonal mime type, will default to 'b2/x-auto' if not provided
-        data: 'data', // this is expecting a Buffer not an encoded string,
+        mime: '', // optional mime type, will default to 'b2/x-auto' if not provided
+        data: 'data', // this is expecting a Buffer, not an encoded string
+        hash: 'sha1-hash', // optional data hash, will use sha1(data) if not provided
         info: {
             // optional info headers, prepended with X-Bz-Info- when sent, throws error if more than 10 keys set
             // valid characters should be a-z, A-Z and '-', all other characters will cause an error to be thrown

--- a/lib/actions/file.js
+++ b/lib/actions/file.js
@@ -10,6 +10,7 @@ exports.uploadFile = function(b2, args) {
     var uploadAuthToken = args.uploadAuthToken;
     var filename = utils.getUrlEncodedFileName(args.filename);
     var data = args.data;
+    var hash = args.hash;
     var info = args.info;
     var mime = args.mime;
 
@@ -20,7 +21,7 @@ exports.uploadFile = function(b2, args) {
             Authorization: uploadAuthToken,
             'Content-Type': mime || 'b2/x-auto',
             'X-Bz-File-Name': filename,
-            'X-Bz-Content-Sha1': data ? sha1(data) : null
+            'X-Bz-Content-Sha1': hash || (data ? sha1(data) : null)
         },
         data: data,
         onUploadProgress: args.onUploadProgress || null

--- a/lib/b2.js
+++ b/lib/b2.js
@@ -39,6 +39,7 @@ B2.prototype.getUploadUrl = function(bucketId) {
 // - uploadAuthToken
 // - filename
 // - data
+// - hash (optional)
 B2.prototype.uploadFile = function(args) {
     return actions.file.uploadFile(this, args);
 };

--- a/test/unit/lib/actions/fileTest.js
+++ b/test/unit/lib/actions/fileTest.js
@@ -178,6 +178,49 @@ describe('actions/file', function() {
 
         });
 
+        describe('with no hash specified', function() {
+
+            beforeEach(function(done) {
+                options = {
+                    uploadUrl: 'https://uploadUrl',
+                    uploadAuthToken: 'uploadauthtoken',
+                    filename: 'foo.txt',
+                    data: 'some text file content'
+                };
+
+                file.uploadFile(b2, options).then(function() {
+                    done();
+                });
+            });
+
+            it('should hash the data for x-bz-content-sha1 in headers', function() {
+                expect(requestOptions.headers['X-Bz-Content-Sha1']).to.equal('332e7f863695677895a406aff6d60acf7e84ea22');
+            });
+
+        });
+
+        describe('with hash specified', function() {
+
+            beforeEach(function(done) {
+                options = {
+                    uploadUrl: 'https://uploadUrl',
+                    uploadAuthToken: 'uploadauthtoken',
+                    filename: 'foo.txt',
+                    data: 'some text file content',
+                    hash: 'my hash value'
+                };
+
+                file.uploadFile(b2, options).then(function() {
+                    done();
+                });
+            });
+
+            it('should properly set x-bz-content-sha1 in headers', function() {
+                expect(requestOptions.headers['X-Bz-Content-Sha1']).to.equal('my hash value');
+            });
+
+        });
+
     });
 
 


### PR DESCRIPTION
As discussed in #32, this potentially allows the library to be used with streams.

Ideally, we'd check if `data` is a stream before defaulting to `sha1()`, but this is a start.