### PR TITLE
Add optional contentLength to uploadFile args

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ var response = await this.b2.finishLargeFile({
         uploadUrl: 'uploadUrl',
         uploadAuthToken: 'uploadAuthToken',
         filename: 'filename',
+        contentLength: '', // optional contentLength, will default to data.byteLength if not provided
         mime: '', // optional mime type, will default to 'b2/x-auto' if not provided
         data: 'data', // this is expecting a Buffer, not an encoded string
         hash: 'sha1-hash', // optional data hash, will use sha1(data) if not provided

--- a/lib/actions/file.js
+++ b/lib/actions/file.js
@@ -21,7 +21,7 @@ exports.uploadFile = function(b2, args) {
         headers: {
             Authorization: uploadAuthToken,
             'Content-Type': mime || 'b2/x-auto',
-            'Content-Length': contentLength || data.byteLength ? data.byteLength : data.length,
+            'Content-Length': contentLength || (data.byteLength ? data.byteLength : data.length),
             'X-Bz-File-Name': filename,
             'X-Bz-Content-Sha1': hash || (data ? sha1(data) : null)
         },

--- a/lib/actions/file.js
+++ b/lib/actions/file.js
@@ -9,6 +9,7 @@ exports.uploadFile = function(b2, args) {
     var uploadUrl = args.uploadUrl;
     var uploadAuthToken = args.uploadAuthToken;
     var filename = utils.getUrlEncodedFileName(args.filename);
+    var contentLength = args.contentLength;
     var data = args.data;
     var hash = args.hash;
     var info = args.info;
@@ -20,7 +21,7 @@ exports.uploadFile = function(b2, args) {
         headers: {
             Authorization: uploadAuthToken,
             'Content-Type': mime || 'b2/x-auto',
-            'Content-Length': data.byteLength ? data.byteLength : data.length,
+            'Content-Length': contentLength || data.byteLength ? data.byteLength : data.length,
             'X-Bz-File-Name': filename,
             'X-Bz-Content-Sha1': hash || (data ? sha1(data) : null)
         },


### PR DESCRIPTION
If `data` is a stream instead of a buffer, we are unable to get `data.byteLength` or `data.length`, so we can add an optional contentLength to be supplied to uploadFile args.