### PR TITLE
Prevent doublehash

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,8 @@ var response = await this.b2.finishLargeFile({
       partNumber: 'partNumber', // A number from 1 to 10000
       uploadUrl: 'uploadUrl',
       uploadAuthToken: 'uploadAuthToken', // comes from getUploadPartUrl();
-      data: Buffer // this is expecting a Buffer not an encoded string,
+      data: Buffer, // this is expecting a Buffer not an encoded string,
+      hash: 'sha1-hash', // optional data hash, will use sha1(data) if not provided
       onUploadProgress: function(event) || null // progress monitoring
     }) // returns promise
 

--- a/lib/actions/file.js
+++ b/lib/actions/file.js
@@ -64,7 +64,7 @@ exports.uploadPart = function(b2, args) {
         headers: {
             Authorization: args.uploadAuthToken,
             'X-Bz-Part-Number': args.partNumber,
-            'X-Bz-Content-Sha1': args.data ? sha1(args.data) : null
+            'X-Bz-Content-Sha1': args.hash || (args.data ? sha1(args.data) : null)
         },
         data: args.data,
         onUploadProgress: args.onUploadProgress || null


### PR DESCRIPTION
During a large file upload you upload each "chunk", during the upload the sha1 hash should be calculated. Currently it's done inside the uploadPart function (uploadFile has a hash parameter), yet the finishLargeFile also requires the list of hashes, so obviously the caller will also calculate the hash.

By extending the uploadPart with an optional "hash" parameter we can prevent double hashing (for finishLargeFile by the caller, for uploadPart by the library). 