### PR TITLE
Update to expose get bucket API call

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,13 @@ b2.deleteBucket(bucketId);  // returns promise
 // list buckets
 b2.listBuckets();  // returns promise
 
-// update bucket2
+// get the bucket
+b2.getBucket({
+    bucketName, 
+    bucketId // optional
+});  // returns promise
+
+// update bucket
 b2.updateBucket(bucketId, bucketType);  // returns promise
 
 // get upload url

--- a/lib/actions/bucket.js
+++ b/lib/actions/bucket.js
@@ -47,6 +47,29 @@ exports.list = function(b2) {
     return request.sendRequest(options);
 };
 
+// https://www.backblaze.com/b2/docs/b2_list_buckets.html
+exports.get = function(b2, args) {
+    const data = {
+        accountId: b2.accountId,
+    };
+
+    // only one of these can/should be used at a time
+    if (args.bucketName) {
+        data.bucketName = args.bucketName;
+    } else if (args.bucketId) {
+        data.bucketId = args.bucketId;
+    }
+
+    var options = {
+        url: getListUrl(b2),
+        method: 'POST',
+        data,
+        headers: utils.getAuthHeaderObjectWithToken(b2)
+
+    };
+    return request.sendRequest(options);
+};
+
 exports.update = function(b2, bucketId, bucketType) {
     var options = {
         url: getUpdateUrl(b2),

--- a/lib/b2.js
+++ b/lib/b2.js
@@ -26,6 +26,13 @@ B2.prototype.listBuckets = function() {
     return actions.bucket.list(this);
 };
 
+// args:
+// - bucketName
+// - bucketId
+B2.prototype.getBucket = function(args) {
+    return actions.bucket.get(this, args);
+};
+
 B2.prototype.updateBucket = function(bucketId, bucketType) {
     return actions.bucket.update(this, bucketId, bucketType);
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -51,6 +51,7 @@ exports.saveAuthContext = function (context, authResponse) {
     context.authorizationToken = authResponse.authorizationToken;
     context.apiUrl = authResponse.apiUrl;
     context.downloadUrl = authResponse.downloadUrl;
+    context.accountId = authResponse.accountId;
 };
 
 exports.getProcessFileSuccess = function(deferred) {

--- a/test/unit/lib/actions/bucketTest.js
+++ b/test/unit/lib/actions/bucketTest.js
@@ -185,6 +185,81 @@ describe('actions/bucket', function() {
 
     });
 
+    describe('get', function() {
+
+        describe('with good response', function() {
+
+            beforeEach(function(done) {
+                response = {
+                    buckets:[
+                        {
+                            accountId: '98765',
+                            bucketId: '1234abcd',
+                            bucketName: 'bucket-foo',
+                            bucketType: 'allPrivate',
+                            bucketInfo: {},
+                            corsRules: [],
+                            lifecycleRules: [],
+                            revision: 1
+                        }
+                    ]
+                };
+
+                bucket.get(b2, {bucketName: 'bucket-foo'}).then((response) => {
+                    actualResponse = response;
+                    done();
+                });
+            });
+
+            it('should set correct options and resolve with good response', function() {
+                expect(actualResponse).to.eql(response);
+                expect(requestOptions).to.eql({
+                    method: 'POST',
+                    url: 'https://foo/b2api/v2/b2_list_buckets',
+                    data: {
+                        accountId: '98765',
+                        bucketName: 'bucket-foo'
+                    },
+                    headers: { Authorization: 'unicorns and rainbows' }
+                });
+            });
+        });
+
+        describe('with response containing no buckets', function() {
+
+            beforeEach(function(done) {
+                errorMessage = 'unauthorized';
+
+                bucket.get(b2, {bucketName: 'not-a-real-bucket'}).then(null, function(error) {
+                    actualResponse = error;
+                    done();
+                });
+            });
+
+            it('Should respond with an error and reject promise', function() {
+                // status code is 401
+                expect(actualResponse).to.be(errorMessage);
+            });
+        });
+
+        describe('with error response', function() {
+
+            beforeEach(function(done) {
+                errorMessage = 'Something went wrong';
+
+                bucket.get(b2, {}).then(null, function(error) {
+                    actualResponse = error;
+                    done();
+                });
+            });
+
+            it('Should respond with an error and reject promise', function() {
+                expect(actualResponse).to.be(errorMessage);
+            });
+        });
+
+    });
+
     describe('update', function() {
 
         describe('with good response', function() {


### PR DESCRIPTION
- update docs
- add getBucket unit test

Updated to support more `v2` features. Namely, bucket restrictions: https://www.backblaze.com/b2/docs/b2_list_buckets.html