### PR TITLE
Add contentLength param to uploadFile()

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ b2.uploadFile({
     uploadUrl: 'uploadUrl',
     uploadAuthToken: 'uploadAuthToken',
     fileName: 'fileName',
+    contentLength: 0, // optional data length, will default to data.byteLength or data.length if not provided
     mime: '', // optional mime type, will default to 'b2/x-auto' if not provided
     data: 'data', // this is expecting a Buffer, not an encoded string
     hash: 'sha1-hash', // optional data hash, will use sha1(data) if not provided

--- a/lib/actions/file.js
+++ b/lib/actions/file.js
@@ -14,6 +14,7 @@ exports.uploadFile = function(b2, args) {
     const hash = args.hash;
     const info = args.info;
     const mime = args.mime;
+    const len = args.contentLength || data.byteLength || data.length;
 
     const options = {
         url: uploadUrl,
@@ -21,7 +22,7 @@ exports.uploadFile = function(b2, args) {
         headers: {
             Authorization: uploadAuthToken,
             'Content-Type': mime || 'b2/x-auto',
-            'Content-Length': data.byteLength || data.length,
+            'Content-Length': len,
             'X-Bz-File-Name': fileName,
             'X-Bz-Content-Sha1': hash || (data ? sha1(data) : null)
         },

--- a/test/unit/lib/actions/fileTest.js
+++ b/test/unit/lib/actions/fileTest.js
@@ -228,6 +228,23 @@ describe('actions/file', function() {
 
         });
 
+        describe('with contentLength specified', function() {
+
+            beforeEach(function(done) {
+                options.data = 'more than 3';
+                options.contentLength = 3;
+
+                file.uploadFile(b2, options).then(function() {
+                    done();
+                });
+            });
+
+            it('should override Content-Length header', function() {
+                expect(requestOptions.headers['Content-Length']).to.equal(3);
+            });
+
+        });
+
     });
 
     describe('uploadPart', function() {


### PR DESCRIPTION
Same as PR #46, but with test coverage. I wasn't sure how or if I could modify that PR, so I just made a new one.

From old PR:

> If `data` is a stream instead of a buffer, we are unable to get `data.byteLength` or `data.length`, so we can add an optional contentLength to be supplied to uploadFile args.