### PR TITLE
Add support for key operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,33 @@ b2.cancelLargeFile({
     fileId: 'fileId'
     // ...common arguments (optional)
 }); // returns promise
+
+// create key
+b2.createKey({
+    capabilities: [
+        'readFiles',                    // option 1
+        b2.KEY_CAPABILITIES.READ_FILES, // option 2
+        // see https://www.backblaze.com/b2/docs/b2_create_key.html for full list
+    ],
+    keyName: 'my-key-1', // letters, numbers, and '-' only, <=100 chars
+    validDurationInSeconds: 3600, // expire after duration (optional)
+    bucketId: 'bucketId', // restrict access to bucket (optional)
+    namePrefix: 'prefix_', // restrict access to file prefix (optional)
+    // ...common arguments (optional)
+});  // returns promise
+
+// delete key
+b2.deleteKey({
+    applicationKeyId: 'applicationKeyId',
+    // ...common arguments (optional)
+});  // returns promise
+
+// list keys
+b2.listKeys({
+    maxKeyCount: 10, // limit number of keys returned (optional)
+    startApplicationKeyId: '...', // use `nextApplicationKeyId` from previous response when `maxKeyCount` is set (optional)
+    // ...common arguments (optional)
+});  // returns promise
 ```
 
 ### Uploading Large Files Example

--- a/lib/actions/index.js
+++ b/lib/actions/index.js
@@ -1,5 +1,6 @@
 module.exports = {
     auth: require('./auth'),
     bucket: require('./bucket'),
-    file: require('./file')
+    file: require('./file'),
+    key: require('./key'),
 };

--- a/lib/actions/key.js
+++ b/lib/actions/key.js
@@ -50,3 +50,53 @@ exports.create = function(b2, args) {
         _.get(args, 'axiosOverride', {})
     ));
 };
+
+/**
+ * @param {B2}     b2
+ * @param {object} args
+ * @param {string} args.applicationKeyId
+ */
+exports.delete = function(b2, args) {
+    const options = {
+        url: endpoints(b2).deleteKeyUrl,
+        method: 'POST',
+        headers: utils.getAuthHeaderObjectWithToken(b2),
+        data: {
+            applicationKeyId: args.applicationKeyId,
+        }
+    };
+    // merge order matters here: later objects override earlier objects
+    return request.sendRequest(_.merge({},
+        _.get(args, 'axios', {}),
+        options,
+        _.get(args, 'axiosOverride', {})
+    ));
+};
+
+/**
+ * @param {B2}     b2
+ * @param {object} [args]
+ * @param {number} args.[maxKeyCount]
+ * @param {string} args.[startApplicationKeyId]
+ */
+exports.list = function(b2, args) {
+    const maxKeyCount = args && args.maxKeyCount;
+    const startApplicationKeyId = args && args.startApplicationKeyId;
+
+    const options = {
+        url: endpoints(b2).listKeysUrl,
+        method: 'POST',
+        headers: utils.getAuthHeaderObjectWithToken(b2),
+        data: {
+            accountId: b2.accountId,
+            maxKeyCount,
+            startApplicationKeyId,
+        }
+    };
+    // merge order matters here: later objects override earlier objects
+    return request.sendRequest(_.merge({},
+        _.get(args, 'axios', {}),
+        options,
+        _.get(args, 'axiosOverride', {})
+    ));
+};

--- a/lib/actions/key.js
+++ b/lib/actions/key.js
@@ -1,0 +1,52 @@
+const _ = require('lodash');
+const utils = require('./../utils');
+const request = require('../request');
+const endpoints = require('../endpoints');
+
+exports.CAPABILITIES = {
+    LIST_KEYS: 'listKeys',
+    WRITE_KEYS: 'writeKeys',
+    DELETE_KEYS: 'deleteKeys',
+
+    LIST_BUCKETS: 'listBuckets',
+    WRITE_BUCKETS: 'writeBuckets',
+    DELETE_BUCKETS: 'deleteBuckets',
+
+    LIST_FILES: 'listFiles',
+    READ_FILES: 'readFiles',
+    SHARE_FILES: 'shareFiles',
+    WRITE_FILES: 'writeFiles',
+    DELETE_FILES: 'deleteFiles',
+};
+
+/**
+ * @param {B2}       b2
+ * @param {object}   args
+ * @param {string[]} args.capabilities
+ * @param {string}   args.keyName
+ * @param {number}   args.[validDurationInSeconds] - expire key after seconds
+ * @param {string}   args.[bucketId] - restrict key access to bucket
+ * @param {string}   args.[namePrefix] - restrict key access to files starting
+ *                                       with prefix (bucketId required)
+ */
+exports.create = function(b2, args) {
+    const options = {
+        url: endpoints(b2).createKeyUrl,
+        method: 'POST',
+        headers: utils.getAuthHeaderObjectWithToken(b2),
+        data: {
+            accountId:              b2.accountId,
+            capabilities:           args.capabilities,
+            keyName:                args.keyName,
+            validDurationInSeconds: args.validDurationInSeconds,
+            bucketId:               args.bucketId,
+            namePrefix:             args.namePrefix,
+        }
+    };
+    // merge order matters here: later objects override earlier objects
+    return request.sendRequest(_.merge({},
+        _.get(args, 'axios', {}),
+        options,
+        _.get(args, 'axiosOverride', {})
+    ));
+};

--- a/lib/b2.js
+++ b/lib/b2.js
@@ -154,6 +154,18 @@ B2.prototype.uploadPart = function(args) {
     return actions.file.uploadPart(this, args);
 };
 
+B2.prototype.KEY_CAPABILITIES = actions.key.CAPABILITIES;
+
+// args:
+// - capabilities
+// - keyName
+// - [validDurationInSeconds]
+// - [bucketId]
+// - [namePrefix]
+B2.prototype.createKey = function(args) {
+    return actions.key.create(this, args);
+};
+
 function notYetImplemented() {
     return Promise.reject('Feature not yet implemented');
 }

--- a/lib/b2.js
+++ b/lib/b2.js
@@ -166,6 +166,19 @@ B2.prototype.createKey = function(args) {
     return actions.key.create(this, args);
 };
 
+// args:
+// - applicationKeyId
+B2.prototype.deleteKey = function(args) {
+    return actions.key.delete(this, args);
+};
+
+// args:
+// - [maxKeyCount]
+// - [startApplicationKeyId]
+B2.prototype.listKeys = function(args) {
+    return actions.key.list(this, args);
+};
+
 function notYetImplemented() {
     return Promise.reject('Feature not yet implemented');
 }

--- a/lib/endpoints.js
+++ b/lib/endpoints.js
@@ -9,6 +9,7 @@ module.exports = function(b2) {
         listBucketUrl: `${apiUrl}/b2_list_buckets`,
         updateBucketUrl: `${apiUrl}/b2_update_bucket`,
         getBucketUploadUrl: `${apiUrl}/b2_get_upload_url`,
+
         // file actions
         listFilesUrl: `${apiUrl}/b2_list_file_names`,
         listFileVersionsUrl: `${apiUrl}/b2_list_file_versions`,
@@ -25,6 +26,9 @@ module.exports = function(b2) {
         startLargeFileUrl: `${apiUrl}/b2_start_large_file`,
         getUploadPartUrl: `${apiUrl}/b2_get_upload_part_url`,
         finishLargeFileUrl: `${apiUrl}/b2_finish_large_file`,
-        cancelLargeFileUrl: `${apiUrl}/b2_cancel_large_file`
+        cancelLargeFileUrl: `${apiUrl}/b2_cancel_large_file`,
+
+        // key actions
+        createKeyUrl: `${apiUrl}/b2_create_key`,
     };
 };

--- a/lib/endpoints.js
+++ b/lib/endpoints.js
@@ -30,5 +30,7 @@ module.exports = function(b2) {
 
         // key actions
         createKeyUrl: `${apiUrl}/b2_create_key`,
+        deleteKeyUrl: `${apiUrl}/b2_delete_key`,
+        listKeysUrl: `${apiUrl}/b2_list_keys`,
     };
 };

--- a/test/unit/lib/actions/keyTest.js
+++ b/test/unit/lib/actions/keyTest.js
@@ -1,0 +1,120 @@
+/* global describe, beforeEach, it */
+
+const expect = require('expect.js');
+
+const request = require('../../../../lib/request');
+const utils = require('../../../../lib/utils');
+const key = require('../../../../lib/actions/key');
+
+describe('actions/key', function() {
+    let requestOptions;
+    let bogusRequestModule;
+    let response;
+    let actualResponse;
+    let errorMessage;
+    let b2;
+
+    beforeEach(function() {
+        errorMessage = undefined;
+        actualResponse = undefined;
+
+        b2 = {
+            accountId: '98765',
+            authorizationToken: 'unicorns and rainbows',
+            apiUrl: 'https://foo'
+        };
+
+        bogusRequestModule = function(options, cb) {
+            let deferred = new utils.Deferred();
+            requestOptions = options;
+            cb(errorMessage, false, JSON.stringify(response), deferred);
+
+            return deferred.promise;
+        };
+
+        request.setup(bogusRequestModule);
+    });
+
+    describe('create', function() {
+
+        describe('with good response', function() {
+
+            beforeEach(function(done) {
+                const options = {
+                    capabilities: [
+                        key.CAPABILITIES.READ_FILES,
+                        key.CAPABILITIES.WRITE_FILES,
+                    ],
+                    keyName: 'my-key',
+                    validDurationInSeconds: 3600,
+                    bucketId: '1234abcd',
+                    namePrefix: 'special_file_',
+                };
+
+                response = {
+                    keyName: 'my-key',
+                    applicationKeyId: '9876zyxw',
+                    applicationKey: 'superdupersecret',
+                    capabilities: [
+                        'readFiles',
+                        'writeFiles',
+                    ],
+                    accountId: '98765',
+                    expirationTimestamp: 1570724488688,
+                    bucketId: '1234abcd',
+                    namePrefix: 'special_file_',
+                };
+
+                key.create(b2, options).then(function(response) {
+                    actualResponse = response;
+                    done();
+                });
+            });
+
+            it('should set correct options and resolve with good response', function() {
+                expect(actualResponse).to.eql(response);
+                expect(requestOptions).to.eql({
+                    url: 'https://foo/b2api/v2/b2_create_key',
+                    method: 'POST',
+                    data: {
+                        accountId: '98765',
+                        capabilities: [
+                            'readFiles',
+                            'writeFiles',
+                        ],
+                        keyName: 'my-key',
+                        validDurationInSeconds: 3600,
+                        bucketId: '1234abcd',
+                        namePrefix: 'special_file_',
+                    },
+                    headers: { Authorization: 'unicorns and rainbows' }
+                });
+            });
+        });
+
+        describe('with error response', function() {
+
+            beforeEach(function(done) {
+                const options = {
+                    capabilities: [],
+                    keyName: 'my invalid key with spaces',
+                    validDurationInSeconds: -3600,
+                    namePrefix: 'no-bucket-id-given...',
+                };
+
+                errorMessage = 'Something went wrong';
+
+                key.create(b2, options).then(null, function(error) {
+                    actualResponse = error;
+                    done();
+                });
+            });
+
+            it('Should respond with an error and reject promise', function() {
+                expect(actualResponse).to.be(errorMessage);
+            });
+        });
+
+    });
+
+});

--- a/test/unit/lib/actions/keyTest.js
+++ b/test/unit/lib/actions/keyTest.js
@@ -117,4 +117,142 @@ describe('actions/key', function() {
 
     });
 
+    describe('delete', function() {
+
+        describe('with good response', function() {
+
+            beforeEach(function(done) {
+                const options = {
+                    applicationKeyId: '9876zyxw',
+                };
+
+                response = {
+                    keyName: 'my-key',
+                    applicationKeyId: '9876zyxw',
+                    capabilities: [
+                        'readFiles',
+                        'writeFiles',
+                    ],
+                    accountId: '98765',
+                    expirationTimestamp: 1570724488688,
+                    bucketId: '1234abcd',
+                    namePrefix: 'special_file_',
+                };
+
+                key.delete(b2, options).then(function(response) {
+                    actualResponse = response;
+                    done();
+                });
+            });
+
+            it('should set correct options and resolve with good response', function() {
+                expect(actualResponse).to.eql(response);
+                expect(requestOptions).to.eql({
+                    method: 'POST',
+                    url: 'https://foo/b2api/v2/b2_delete_key',
+                    data: {
+                        applicationKeyId: '9876zyxw',
+                    },
+                    headers: { Authorization: 'unicorns and rainbows' }
+                });
+            });
+        });
+
+        describe('with error response', function() {
+
+            beforeEach(function(done) {
+                const options = {
+                    applicationKeyId: 'invalid key id',
+                };
+
+                errorMessage = 'Something went wrong';
+
+                key.delete(b2, options).then(null, function(error) {
+                    actualResponse = error;
+                    done();
+                });
+            });
+
+            it('Should respond with an error and reject promise', function() {
+                expect(actualResponse).to.be(errorMessage);
+            });
+        });
+
+    });
+
+    describe('list', function() {
+
+        describe('with good response', function() {
+
+            beforeEach(function(done) {
+                const options = {
+                    maxKeyCount: 10,
+                    startApplicationKeyId: 'my-key-1',
+                };
+
+                response = {
+                    keys: [
+                        {
+                            keyName: 'my-key-1',
+                            applicationKeyId: '9876zyxw',
+                            capabilities: [
+                                'readFiles',
+                                'writeFiles',
+                            ],
+                            accountId: '98765',
+                            expirationTimestamp: 1570724488688,
+                            bucketId: '1234abcd',
+                            namePrefix: 'special_file_',
+                        },
+                        {
+                            keyName: 'my-key-2',
+                            applicationKeyId: '8765yxwv',
+                            capabilities: [
+                                'readFiles',
+                            ],
+                            accountId: '98765',
+                        }
+                    ],
+                    nextApplicationKeyId: null,
+                };
+
+                key.list(b2, options).then(function(response) {
+                    actualResponse = response;
+                    done();
+                });
+            });
+
+            it('should set correct options and resolve with good response', function() {
+                expect(actualResponse).to.eql(response);
+                expect(requestOptions).to.eql({
+                    method: 'POST',
+                    url: 'https://foo/b2api/v2/b2_list_keys',
+                    data: {
+                        accountId: '98765',
+                        maxKeyCount: 10,
+                        startApplicationKeyId: 'my-key-1',
+                    },
+                    headers: { Authorization: 'unicorns and rainbows' }
+                });
+            });
+        });
+
+        describe('with error response', function() {
+
+            beforeEach(function(done) {
+                errorMessage = 'Something went wrong';
+
+                key.list(b2).then(null, function(error) {
+                    actualResponse = error;
+                    done();
+                });
+            });
+
+            it('Should respond with an error and reject promise', function() {
+                expect(actualResponse).to.be(errorMessage);
+            });
+        });
+
+    });
+
 });


### PR DESCRIPTION
Implemented `b2_create_key`, `b2_delete_key`, and `b2_list_keys` to address #77.

I used JSDoc in a couple places, which doesn't appear to be used elsewhere in the codebase. Personally, I prefer the extra documentation, but let me know if there's a better way to handle that.

Also, if you guys have any ideas on how to make the tests more thorough, I'd be happy to hear them! Currently, they feel a little hollow. However, given that these functions are really just shuffling arguments to the API, there's not much more we can do, short of writing end-to-end tests. I manually tested the functions for a little more peace of mind.