### PR TITLE
add optional contentLength param to uploadPart

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,8 @@ b2.uploadPart({
     uploadAuthToken: 'uploadAuthToken', // comes from getUploadPartUrl();
     data: Buffer // this is expecting a Buffer not an encoded string,
     hash: 'sha1-hash', // optional data hash, will use sha1(data) if not provided
-    onUploadProgress: (event) => {} || null // progress monitoring
+    onUploadProgress: (event) => {} || null, // progress monitoring
+    contentLength: 0, // optional data length, will default to data.byteLength or data.length if not provided
     // ...common arguments (optional)
 }); // returns promise
 

--- a/lib/actions/file.js
+++ b/lib/actions/file.js
@@ -84,7 +84,7 @@ exports.uploadPart = function(b2, args) {
         method: 'POST',
         headers: {
             Authorization: args.uploadAuthToken,
-            'Content-Length': args.data.byteLength || args.data.length,
+            'Content-Length': args.contentLength || args.data.byteLength || args.data.length,
             'X-Bz-Part-Number': args.partNumber,
             'X-Bz-Content-Sha1': args.hash || (args.data ? sha1(args.data) : null)
         },

--- a/test/unit/lib/actions/fileTest.js
+++ b/test/unit/lib/actions/fileTest.js
@@ -295,6 +295,21 @@ describe('actions/file', function() {
                 expect(requestOptions.headers['X-Bz-Content-Sha1']).to.equal('332e7f863695677895a406aff6d60acf7e84ea22');
             });
         });
+
+        describe('with contentLength specified', function() {
+            beforeEach(function(done) {
+                options.data = 'more than 3';
+                options.contentLength = 3;
+
+                file.uploadPart(b2, options).then(function() {
+                    done();
+                });
+            });
+
+            it('should override Content-Length header', function() {
+                expect(requestOptions.headers['Content-Length']).to.equal(3);
+            });
+        });
     });
 
     describe('listFileNames', function() {


### PR DESCRIPTION
Allow for same behavior as `uploadFile`, providing specific `contentLength` to override the automatic values of `data.byteLength || data.length`.

Thanks!