### PR TITLE
Add note about 24 hour authorization expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ const b2 = new B2({
 
 async function GetBucket() {
   try {
-    await b2.authorize(); // must authorize first
+    await b2.authorize(); // must authorize first (authorization lasts 24 hrs)
     let response = await b2.getBucket({ bucketName: 'my-bucket' });
     console.log(response.data);
   } catch (err) {
@@ -91,7 +91,7 @@ const common_args = {
     }
 }
 
-// authorize with provided credentials
+// authorize with provided credentials (authorization expires after 24 hours)
 b2.authorize({
     // ...common arguments (optional)
 });  // returns promise


### PR DESCRIPTION
This tripped me up - I think it's worth noting.

Reference: https://www.backblaze.com/b2/docs/application_keys.html

> Use the new application key to get an authorization token that can be use to access the B2 APIs. Authorization tokens are only good for 24 hours. You can use the application key to make new authorization tokens as they expire.

Related issue: https://github.com/yakovkhalinsky/backblaze-b2/issues/56

Thanks!