### PR TITLE
Support passing authorizationToken and URLs to B2

### DIFF
--- a/lib/b2.js
+++ b/lib/b2.js
@@ -7,9 +7,14 @@ function B2(options) {
     this.accountId = options.accountId;
     this.applicationKeyId = options.applicationKeyId;
     this.applicationKey = options.applicationKey;
-    this.authorizationToken = null;
-    this.apiUrl = null;
-    this.downloadUrl = null;
+    this.authorizationToken = options.authorizationToken ?? null;
+    this.apiUrl = options.apiUrl ?? null;
+    this.downloadUrl = options.downloadUrl ?? null;
+
+    //  if authorizationToken is provided, we also need the required URLs
+    if (this.authorizationToken && (!this.apiUrl || !this.downloadUrl)) {
+        throw new Error('When providing authorizationToken, apiUrl and downloadUrl are also required');
+    }
     /*
         allows an optional axios config object that overrides the default axios config
         creates new axios instance so that axios-retry isn't injected into the user's code if they also use axios

--- a/lib/b2.js
+++ b/lib/b2.js
@@ -11,9 +11,11 @@ function B2(options) {
     this.apiUrl = options.apiUrl ?? null;
     this.downloadUrl = options.downloadUrl ?? null;
 
-    //  if authorizationToken is provided, we also need the required URLs
-    if (this.authorizationToken && (!this.apiUrl || !this.downloadUrl)) {
-        throw new Error('When providing authorizationToken, apiUrl and downloadUrl are also required');
+    // if any of authorizationToken, apiUrl or downloadUrl is provided, all must be present
+    if (this.authorizationToken || this.apiUrl || this.downloadUrl) {
+        if (!this.authorizationToken || !this.apiUrl || !this.downloadUrl) {
+            throw new Error('When using pre-authorized credentials, all three authorizationToken, apiUrl, and downloadUrl must be provided');
+        }
     }
     /*
         allows an optional axios config object that overrides the default axios config


### PR DESCRIPTION
Allows B2 to accept authorizationToken, apiUrl, and downloadUrl via options. Throws an error if authorizationToken is provided without the required URLs, improving flexibility for pre-authorized usage.